### PR TITLE
Temp calculation from image row 321

### DIFF
--- a/opencv_uti165k.py
+++ b/opencv_uti165k.py
@@ -1,6 +1,7 @@
 import numpy as np
 import time
 import cv2
+import struct
 
 camera_num = 0
 
@@ -41,6 +42,18 @@ while(True):
     colorframe = cv2.cvtColor(frame, cv2.COLOR_BGR2BGRA)
     # Display the resulting frame
     cv2.imshow('Thermal Camera - Press Q to quit', colorframe)
+    
+    cam.set(cv2.CAP_PROP_CONVERT_RGB, 0)
+    ret, frame = cam.read()
+    if not ret:
+        print("Failed to fetch frame")
+        time.sleep(0.1)
+        continue
+    print("Frame OK! for temp calculation")
+    print(struct.unpack("h", frame[320][0])[0]/10)
+    cam.set(cv2.CAP_PROP_CONVERT_RGB, 1)
+
+    
     if cv2.waitKey(1) & 0xFF == ord('q'):
         break
 


### PR DESCRIPTION
This diff appears to extract the temp data for automated logging.  I've used it to automate thermal image capture and logging of user data based on a prox card swipe for upload to aws services. Have tested it and there is sometimes a 0.1 degree variance between temp that is displayed in the image and the temp that is output in the print statement due to the calculation being done on a different frame than is captured for image viewing. Thanks for the code, and I hope this helps others. I can share my HID access key fob automation code as well if it would help anyone. Here is a video showing the integration. https://youtu.be/h5mQt1Ct9b0